### PR TITLE
Update homepage links to reflect transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyterlab-urdf
 
-[![Github Actions Status](https://github.com/ihuicatl/jupyterlab_urdf/workflows/Build/badge.svg)](https://github.com/ihuicatl/jupyterlab_urdf/actions/workflows/build.yml)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ihuicatl/jupyterlab_urdf/main?urlpath=lab)
+[![Github Actions Status](https://github.com/jupyter-robotics/jupyterlab-urdf/workflows/Build/badge.svg)](https://github.com/jupyter-robotics/jupyterlab-urdf/actions/workflows/build.yml)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-robotics/jupyterlab-urdf/main?urlpath=lab)
 [![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge-launch.svg)](https://jupyterlab-urdf.readthedocs.io/en/latest/lite/lab/index.html?path=robot.urdf)
 
 A URDF viewer and editor extension for JupyterLab.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/ihuicatl/jupyterlab_urdf",
+  "homepage": "https://github.com/jupyter-robotics/jupyterlab-urdf",
   "bugs": {
-    "url": "https://github.com/ihuicatl/jupyterlab_urdf/issues"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-urdf/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -25,7 +25,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ihuicatl/jupyterlab_urdf.git"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-urdf.git"
   },
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Repo transferred from `ihuicatl` to `jupyter-robotics`. Homepage links updated to reflect change. Changelog left unchanged because the links redirect automatically.