### PR TITLE
Update JupyterLab version for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
     - name: Install Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab==4.0.3" jupyterlab_urdf*.whl
+        python -m pip install "jupyterlab>=4.0.5" jupyterlab_urdf*.whl
         jupyter labextension list
 
     - name: Install dependencies


### PR DESCRIPTION
Integration tests failed with JupyterLab=4.0.4
This PR upgrades to JupyterLab=4.0.5 as fixed by https://github.com/jupyterlab/jupyterlab/issues/14960