### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,9 +63,10 @@ html_logo = 'logo.svg'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # JupyterLite
 jupyterlite_config = "jupyterlite_config.json"
 jupyterlite_contents = ["robot.urdf"]
 jupyterlite_dir = "."
+jupyterlite_bind_ipynb_suffix = False


### PR DESCRIPTION
This PR fixes the `jupyterlite_sphinx` error when building documentation

```
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyterlab-urdf/envs/latest/lib/python3.9/site-packages/jupyterlite_sphinx/jupyterlite_sphinx.py", line 121, in __init__
    super().__init__(rawsource, *children, iframe_src=iframe_src, **attributes)
TypeError: jupyterlite_sphinx.jupyterlite_sphinx._PromptedIframe.__init__() got multiple values for keyword argument 'iframe_src'
The full traceback has been saved in /tmp/sphinx-err-ipzrf2gu.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```