### PR TITLE
Issue controls panel UI

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -40,6 +40,35 @@ export class URDFControls extends GUI {
     this.domElement.style.right = '5px';
     this.domElement.setAttribute('class', 'dg main urdf-gui');
 
+    // Add resize functionality
+    let isResizing = false;
+    let startX: number;
+    let startWidth: number;
+
+    this.domElement.addEventListener('mousedown', (e: MouseEvent) => {
+      // Only trigger on left border
+      if (e.clientX < this.domElement.getBoundingClientRect().left + 6) {
+        isResizing = true;
+        startX = e.clientX;
+        startWidth = parseInt(getComputedStyle(this.domElement).width, 10);
+      }
+    });
+
+    document.addEventListener('mousemove', (e: MouseEvent) => {
+      if (!isResizing) return;
+      
+      const width = startWidth - (e.clientX - startX);
+      if (width >= 250 && width <= 500) {
+        this.domElement.style.width = `${width}px`;
+      }
+    });
+
+    document.addEventListener('mouseup', () => {
+      isResizing = false;
+    });
+
+    //
+    
     this._workspaceFolder = this.addFolder('Workspace');
     this._workspaceFolder.domElement.setAttribute(
       'class',

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -43,7 +43,7 @@ export class URDFControls extends GUI {
     // Add resize functionality
     this._setupResizeHandling({
       minWidth: 150,
-      maxWidth: 500,
+      maxWidth: 1000,
       grabZoneWidth: 12
     });
 

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -218,6 +218,9 @@ export class URDFControls extends GUI {
 
   /**
    * Sets up panel resizing functionality
+   * @param minWidth - Minimum width of the panel
+   * @param maxWidth - Maximum width of the panel
+   * @param grabZoneWidth - Width of the area where the mouse can be clicked
    */
   private _setupResizeHandling(options: {
     minWidth: number;

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -230,36 +230,39 @@ export class URDFControls extends GUI {
     let isResizing = false;
     let startX: number;
     let startWidth: number;
-  
+
     const { minWidth, maxWidth, grabZoneWidth } = options;
-  
+
     const onMouseMove = (e: MouseEvent) => {
-      if (!isResizing) return;
-  
+      if (!isResizing) {
+        return;
+      }
+
       const width = startWidth - (e.clientX - startX);
       if (width >= minWidth && width <= maxWidth) {
         this.domElement.style.width = `${width}px`;
       }
     };
-  
+
     const onMouseUp = () => {
       isResizing = false;
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };
-  
+
     this.domElement.addEventListener('mousedown', (e: MouseEvent) => {
-      if (e.clientX < this.domElement.getBoundingClientRect().left + grabZoneWidth) {
+      if (
+        e.clientX <
+        this.domElement.getBoundingClientRect().left + grabZoneWidth
+      ) {
         isResizing = true;
         startX = e.clientX;
         startWidth = parseInt(getComputedStyle(this.domElement).width, 10);
         e.preventDefault();
-  
+
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
       }
     });
   }
-  
 }
-

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -41,34 +41,13 @@ export class URDFControls extends GUI {
     this.domElement.setAttribute('class', 'dg main urdf-gui');
 
     // Add resize functionality
-    let isResizing = false;
-    let startX: number;
-    let startWidth: number;
-
-    this.domElement.addEventListener('mousedown', (e: MouseEvent) => {
-      // Only trigger on left border
-      if (e.clientX < this.domElement.getBoundingClientRect().left + 6) {
-        isResizing = true;
-        startX = e.clientX;
-        startWidth = parseInt(getComputedStyle(this.domElement).width, 10);
-      }
+    this._setupResizeHandling({
+      minWidth: 150,
+      maxWidth: 500,
+      grabZoneWidth: 12
     });
 
-    document.addEventListener('mousemove', (e: MouseEvent) => {
-      if (!isResizing) return;
-      
-      const width = startWidth - (e.clientX - startX);
-      if (width >= 250 && width <= 500) {
-        this.domElement.style.width = `${width}px`;
-      }
-    });
-
-    document.addEventListener('mouseup', () => {
-      isResizing = false;
-    });
-
-    //
-    
+    // Create folders
     this._workspaceFolder = this.addFolder('Workspace');
     this._workspaceFolder.domElement.setAttribute(
       'class',
@@ -236,4 +215,48 @@ export class URDFControls extends GUI {
     }
     return this.controls.joints;
   }
+
+  /**
+   * Sets up panel resizing functionality
+   */
+  private _setupResizeHandling(options: {
+    minWidth: number;
+    maxWidth: number;
+    grabZoneWidth: number;
+  }): void {
+    let isResizing = false;
+    let startX: number;
+    let startWidth: number;
+  
+    const { minWidth, maxWidth, grabZoneWidth } = options;
+  
+    const onMouseMove = (e: MouseEvent) => {
+      if (!isResizing) return;
+  
+      const width = startWidth - (e.clientX - startX);
+      if (width >= minWidth && width <= maxWidth) {
+        this.domElement.style.width = `${width}px`;
+      }
+    };
+  
+    const onMouseUp = () => {
+      isResizing = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  
+    this.domElement.addEventListener('mousedown', (e: MouseEvent) => {
+      if (e.clientX < this.domElement.getBoundingClientRect().left + grabZoneWidth) {
+        isResizing = true;
+        startX = e.clientX;
+        startWidth = parseInt(getComputedStyle(this.domElement).width, 10);
+        e.preventDefault();
+  
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+      }
+    });
+  }
+  
 }
+

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -43,7 +43,6 @@ export class URDFControls extends GUI {
     // Add resize functionality
     this._setupResizeHandling({
       minWidth: 150,
-      maxWidth: 1000,
       grabZoneWidth: 12
     });
 
@@ -224,14 +223,13 @@ export class URDFControls extends GUI {
    */
   private _setupResizeHandling(options: {
     minWidth: number;
-    maxWidth: number;
     grabZoneWidth: number;
   }): void {
     let isResizing = false;
     let startX: number;
     let startWidth: number;
 
-    const { minWidth, maxWidth, grabZoneWidth } = options;
+    const { minWidth, grabZoneWidth } = options;
 
     const onMouseMove = (e: MouseEvent) => {
       if (!isResizing) {
@@ -239,7 +237,7 @@ export class URDFControls extends GUI {
       }
 
       const width = startWidth - (e.clientX - startX);
-      if (width >= minWidth && width <= maxWidth) {
+      if (width >= minWidth) {
         this.domElement.style.width = `${width}px`;
       }
     };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -123,7 +123,7 @@ export class URDFRenderer extends THREE.WebGLRenderer {
    * Adds three lights to the scene
    */
   private _addLights(): void {
-    const directionalLight = new THREE.DirectionalLight(0xff0000, 1.0);
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 1.0);
     directionalLight.castShadow = true;
     directionalLight.position.set(3, 10, 3);
     directionalLight.shadow.camera.top = 2;
@@ -132,12 +132,12 @@ export class URDFRenderer extends THREE.WebGLRenderer {
     directionalLight.shadow.camera.right = 2;
     directionalLight.shadow.camera.near = 0.1;
     directionalLight.shadow.camera.far = 40;
-    //this._scene.add(directionalLight);
+    this._scene.add(directionalLight);
 
-    const ambientLight = new THREE.AmbientLight('#ff0000');
-    ambientLight.intensity = 1;
+    const ambientLight = new THREE.AmbientLight('#fff');
+    ambientLight.intensity = 0.5;
     ambientLight.position.set(0, 5, 0);
-    //this._scene.add(ambientLight);
+    this._scene.add(ambientLight);
 
     const hemisphereLight = new THREE.HemisphereLight(
       this._colorSky,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -123,7 +123,7 @@ export class URDFRenderer extends THREE.WebGLRenderer {
    * Adds three lights to the scene
    */
   private _addLights(): void {
-    const directionalLight = new THREE.DirectionalLight(0xffffff, 1.0);
+    const directionalLight = new THREE.DirectionalLight(0xff0000, 1.0);
     directionalLight.castShadow = true;
     directionalLight.position.set(3, 10, 3);
     directionalLight.shadow.camera.top = 2;
@@ -132,12 +132,12 @@ export class URDFRenderer extends THREE.WebGLRenderer {
     directionalLight.shadow.camera.right = 2;
     directionalLight.shadow.camera.near = 0.1;
     directionalLight.shadow.camera.far = 40;
-    this._scene.add(directionalLight);
+    //this._scene.add(directionalLight);
 
-    const ambientLight = new THREE.AmbientLight('#fff');
-    ambientLight.intensity = 0.5;
+    const ambientLight = new THREE.AmbientLight('#ff0000');
+    ambientLight.intensity = 1;
     ambientLight.position.set(0, 5, 0);
-    this._scene.add(ambientLight);
+    //this._scene.add(ambientLight);
 
     const hemisphereLight = new THREE.HemisphereLight(
       this._colorSky,

--- a/style/base.css
+++ b/style/base.css
@@ -29,16 +29,16 @@
   box-sizing: border-box;
   min-width: 150px;
   max-width: 500px;
-  padding-bottom: 20px; 
+  padding-bottom: 20px;
 }
 
 /* Add a resize handle on the left border */
 .urdf-gui::before {
-  content: "";
+  content: '';
   position: absolute;
-  width: 12px;        
+  width: 12px;
   height: 100%;
-  cursor: ew-resize;  
+  cursor: ew-resize;
 }
 
 .urdf-gui li.folder {
@@ -144,6 +144,6 @@
 /* Style for Dat.GUI's close button */
 .urdf-gui .close-button {
   width: 100% !important;
-  color: white !important; 
+  color: white !important;
   position: absolute;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -144,6 +144,6 @@
 /* Style for Dat.GUI's close button */
 .urdf-gui .close-button {
   width: 100% !important;
-  color: white !important; /* This doesn't used a predefined color */
+  color: white !important; 
   position: absolute;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -36,11 +36,9 @@
 .urdf-gui::before {
   content: "";
   position: absolute;
-  left: -3px;        /* Align with the left border */
-  top: 0;
-  width: 12px;        /* Wider hit area for easier grabbing */
+  width: 12px;        
   height: 100%;
-  cursor: ew-resize;  /* Show resize cursor on the left edge */
+  cursor: ew-resize;  
 }
 
 .urdf-gui li.folder {
@@ -148,11 +146,4 @@
   width: 100% !important;
   color: white !important; /* This doesn't used a predefined color */
   position: absolute;
-  bottom: 0;
-  left: 0;
-}
-
-/* Style for when panel is closed */
-.urdf-gui.closed .close-button {
-  position: relative;  /* Reset position when panel is closed */
 }

--- a/style/base.css
+++ b/style/base.css
@@ -148,6 +148,12 @@
   position: absolute;
 }
 
+/* Expand hover area to reach color pickers */
+.urdf-gui .cr.color .c:hover {
+  padding: 15px 0;
+  margin: -15px 0;
+}
+
 .urdf-gui li.cr.number.has-slider .property-name {
   flex: 1 1;
   padding-right: 15px;
@@ -168,7 +174,7 @@ li.cr.number.has-slider > div {
   display: flex;
 }
 
-/* Styling for Chromium based browsers*/
+/* Styling for Chromium based browsers */
 .urdf-gui li.cr.number.has-slider .property-name:hover::-webkit-scrollbar {
   height: 8px;
 }
@@ -177,10 +183,4 @@ li.cr.number.has-slider > div {
   li.cr.number.has-slider
   .property-name:hover::-webkit-scrollbar-thumb {
   background: #888;
-}
-
-/* Expand hover area to reach color pickers */
-.urdf-gui .cr.color .c:hover {
-  padding: 15px 0;
-  margin: -15px 0;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -28,7 +28,7 @@
   border: none;
   box-sizing: border-box;
   min-width: 150px;
-  max-width: 1000px;
+  max-width: 98%;
   padding-bottom: 20px;
 }
 
@@ -111,7 +111,7 @@
 }
 
 .urdf-gui .c {
-  float: right;
+  float: right !important;
   max-width: 180px;
   position: relative;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -32,7 +32,6 @@
   right: 5px;
   min-width: 250px;
   max-width: 500px;
-  height: 100%;
   border-left: 3px solid var(--gui-color-title-bg);
   z-index: 1;
   overflow-x: hidden;  /* Hide horizontal scrollbar only */
@@ -149,4 +148,18 @@
 .urdf-gui .joints-folder ul {
   max-height: 50vh;
   overflow: scroll;
+}
+
+/* Style for Dat.GUI's close button */
+.urdf-gui .close-button {
+  width: 100% !important;
+  color: white !important; /* This doesn't used a predefined color */
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+/* Style for when panel is closed */
+.urdf-gui.closed .close-button {
+  position: relative;  /* Reset position when panel is closed */
 }

--- a/style/base.css
+++ b/style/base.css
@@ -27,6 +27,28 @@
   color: var(--gui-color-font);
   border: none;
   box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  right: 5px;
+  min-width: 250px;
+  max-width: 500px;
+  height: 100%;
+  border-left: 3px solid var(--gui-color-title-bg);
+  z-index: 1;
+  overflow-x: hidden;  /* Hide horizontal scrollbar only */
+  overflow-y: visible; /* Allow vertical overflow for Dat.GUI elements */
+  padding-bottom: 20px; /* Add space for the toggle button */
+}
+
+/* Add a resize handle on the left border */
+.urdf-gui::before {
+  content: "";
+  position: absolute;
+  left: -3px;        /* Align with the left border */
+  top: 0;
+  width: 6px;        /* Wider hit area for easier grabbing */
+  height: 100%;
+  cursor: ew-resize;  /* Show resize cursor on the left edge */
 }
 
 .urdf-gui li.folder {

--- a/style/base.css
+++ b/style/base.css
@@ -28,7 +28,7 @@
   border: none;
   box-sizing: border-box;
   min-width: 150px;
-  max-width: 500px;
+  max-width: 1000px;
   padding-bottom: 20px;
 }
 
@@ -108,6 +108,12 @@
 
 .urdf-gui .closed li:not(.title) {
   padding: 0;
+}
+
+.urdf-gui .c {
+  float: right;
+  max-width: 180px;
+  position: relative;
 }
 
 .urdf-gui .c .slider {

--- a/style/base.css
+++ b/style/base.css
@@ -110,12 +110,6 @@
   padding: 0;
 }
 
-.urdf-gui .c {
-  float: right !important;
-  max-width: 180px;
-  position: relative;
-}
-
 .urdf-gui .c .slider {
   margin: 0;
   margin-top: 0.5em;
@@ -152,4 +146,35 @@
   width: 100% !important;
   color: white !important;
   position: absolute;
+}
+
+.urdf-gui li.cr.number.has-slider .property-name {
+  flex: 1 1;
+  padding-right: 15px;
+}
+
+.urdf-gui li.cr.number.has-slider .property-name:hover {
+  overflow-x: auto;
+  text-overflow: unset;
+}
+
+/* Adjust the control container */
+.urdf-gui li.cr.number.has-slider .c {
+  flex: 0 1 180px;
+  margin-left: auto;
+}
+
+li.cr.number.has-slider > div {
+  display: flex;
+}
+
+/* Styling for Chromium based browsers*/
+.urdf-gui li.cr.number.has-slider .property-name:hover::-webkit-scrollbar {
+  height: 8px;
+}
+
+.urdf-gui
+  li.cr.number.has-slider
+  .property-name:hover::-webkit-scrollbar-thumb {
+  background: #888;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -27,16 +27,9 @@
   color: var(--gui-color-font);
   border: none;
   box-sizing: border-box;
-  position: absolute;
-  top: 0;
-  right: 5px;
-  min-width: 250px;
+  min-width: 150px;
   max-width: 500px;
-  border-left: 3px solid var(--gui-color-title-bg);
-  z-index: 1;
-  overflow-x: hidden;  /* Hide horizontal scrollbar only */
-  overflow-y: visible; /* Allow vertical overflow for Dat.GUI elements */
-  padding-bottom: 20px; /* Add space for the toggle button */
+  padding-bottom: 20px; 
 }
 
 /* Add a resize handle on the left border */
@@ -45,7 +38,7 @@
   position: absolute;
   left: -3px;        /* Align with the left border */
   top: 0;
-  width: 6px;        /* Wider hit area for easier grabbing */
+  width: 12px;        /* Wider hit area for easier grabbing */
   height: 100%;
   cursor: ew-resize;  /* Show resize cursor on the left edge */
 }


### PR DESCRIPTION
Made the controls panel resizable to manly fix the issue of joint names being too long to read:
-Added the pseudo element .urdf-gui::before in base.css for the invisible handle.
-Added a min and max width for the panel.
-Overwritten style for the "close controls" button to fix some issues.
-Added a function _setupResizeHandling in controls.ts to implement this.