### PR TITLE
Now opens editor and viewer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,13 @@ const extension: JupyterFrontEndPlugin<void> = {
         tracker.save(widget);
       });
       tracker.add(widget);
+
+      // Open editor alongside viewer
+      commands.execute('docmanager:open', {
+      path: widget.context.path,
+      factory: 'Editor'
+      });
+
     });
 
     // Register widget and model factories
@@ -121,20 +128,23 @@ const extension: JupyterFrontEndPlugin<void> = {
       icon: urdf_icon,
       iconClass: 'jp-URDFIcon',
       caption: 'Create a new URDF',
-      execute: () => {
+      execute: async () => {
         const cwd = browserFactory.model.path;
-        commands
-          .execute('docmanager:new-untitled', {
-            path: cwd,
-            type: 'file',
-            ext: '.urdf'
-          })
-          .then(model =>
-            commands.execute('docmanager:open', {
-              path: model.path,
-              factory: FACTORY
-            })
-          );
+        const model = await commands.execute('docmanager:new-untitled', {
+          path: cwd,
+          type: 'file',
+          ext: '.urdf'
+        });
+      
+        await commands.execute('docmanager:open', {
+          path: model.path,
+          factory: FACTORY
+        });
+      
+        await commands.execute('docmanager:open', {
+          path: model.path,
+          factory: 'Editor'
+        });
       }
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,10 +101,9 @@ const extension: JupyterFrontEndPlugin<void> = {
 
       // Open editor alongside viewer
       commands.execute('docmanager:open', {
-      path: widget.context.path,
-      factory: 'Editor'
+        path: widget.context.path,
+        factory: 'Editor'
       });
-
     });
 
     // Register widget and model factories
@@ -135,12 +134,12 @@ const extension: JupyterFrontEndPlugin<void> = {
           type: 'file',
           ext: '.urdf'
         });
-      
+
         await commands.execute('docmanager:open', {
           path: model.path,
           factory: FACTORY
         });
-      
+
         await commands.execute('docmanager:open', {
           path: model.path,
           factory: 'Editor'


### PR DESCRIPTION
Made the urdf view open with the editor when:
-Creating a new urdf file.
-Opening an existing urdf file (by double-clicking on one from the file browser for example). Also improved the readability of the function that handles this by making it asynchronous.