### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
-  #   configuration: docs/conf.py
+  configuration: docs/conf.py
   fail_on_warning: false
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF


### PR DESCRIPTION
Uncommented the readthedocs configuration line that was causing the readthedocs build test for pull requests.